### PR TITLE
add fully qualified DesktopLauncher to desktop.gradle

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "java"
 sourceCompatibility = 1.6
 sourceSets.main.java.srcDirs = [ "src/" ]
 
-project.ext.mainClassName = "DesktopLauncher"
+project.ext.mainClassName = "com.jmrapp.terralegion.desktop.DesktopLauncher"
 project.ext.assetsDir = new File("../android/assets");
 
 task run(dependsOn: classes, type: JavaExec) {


### PR DESCRIPTION
This enables you to run the desktop app through the gradle task like so:
`> ./gradlew desktop:run`
