### PR TITLE
Update android gradle plugin from 1.3 to 2.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,17 +9,13 @@ android {
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
+            jniLibs.srcDir 'libs'
         }
 
         instrumentTest.setRoot('tests')
     }
 }
 
-// needed to add JNI shared libraries to APK when compiling on CLI
-tasks.withType(com.android.build.gradle.tasks.PackageApplication) { pkgTask ->
-    pkgTask.jniFolders = new HashSet<File>()
-    pkgTask.jniFolders.add(new File(projectDir, 'libs'))
-}
 
 // called every time gradle gets executed, takes the native dependencies of
 // the natives configuration, and extracts them to the proper libs/ folders

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.5'
-        classpath 'com.android.tools.build:gradle:1.3.0'
-        classpath 'org.robovm:robovm-gradle-plugin:1.0.0-alpha-04'
+        classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
+        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'org.robovm:robovm-gradle-plugin:1.12.0'
     }
 }
 
@@ -18,7 +18,7 @@ allprojects {
     ext {
         appName = 'TerraLegion'
         gdxVersion = '1.4.1'
-        roboVMVersion = '1.0.0-alpha-04'
+        roboVMVersion = '1.12.0'
         box2DLightsVersion = '1.3'
         ashleyVersion = '1.3.1'
         aiVersion = '1.4.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xms128m -Xmx512m
+org.gradle.jvmargs=-Xms128m -Xmx1536m
 org.gradle.configureondemand=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 05 20:43:12 PDT 2016
+#Sat Jul 09 09:51:51 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
1.3 is from almost a year ago! With v2.1 we upgrade the actual gradle version from 2.2 to 2.10 (see change to gradle-wrapper.properties).  

This should greatly improve gradle build times and enable some cool android studio options like instant run.
